### PR TITLE
Change dd block size to megabytes

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -33,8 +33,8 @@ func Create(name, path string, gigaBytes int) error {
 	args := []string{
 		"if=/dev/zero",
 		fmt.Sprintf("of=%s", imagePath),
-		"bs=1G",
-		fmt.Sprintf("count=%d", gigaBytes),
+		"bs=1M",
+		fmt.Sprintf("count=%d", gigaBytes*1024),
 	}
 
 	output, err := exec.Command(dd, args...).CombinedOutput()


### PR DESCRIPTION
Currently the block size of dd is set to 1 gigabyte which leads to dd allocating that memory before syncing it to the file on disk. This can cause problems on environments with low memory so I changed it to a block size of 1 megabyte.